### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ Ensure you have the following software installed on your machine:
 Once the dependencies are installed, start the development server:
 
 ```bash
-npm start
+npm run dev
 ```
 
 Or, with yarn:
 
 ```bash
-yarn start
+yarn dev
 ```
 
 The development server should start running, and you should be able to access the portfolio website in your browser at http://localhost:3000.


### PR DESCRIPTION
changed line 63 and 69 from `npm start` to `npm run dev' and 'yarn start` to `yarn dev` respectively